### PR TITLE
KTB.tsv, KTB_entries.txtでのEmbedded_omittedは実際にはEmbedded-omittedに見える

### DIFF
--- a/KTB.tsv
+++ b/KTB.tsv
@@ -45,7 +45,7 @@
 #
 #   Group b -- Embedded headword
 #   3 Embedded_clerical       埋字 隸書字體
-#   4 Embedded_omitted        埋字 脫落
+#   4 Embedded-omitted        埋字 脫落
 #   5 Embedded_seal           埋字 篆書字體
 #
 #   Group c -- Omitted headword

--- a/KTB_entries.txt
+++ b/KTB_entries.txt
@@ -43,7 +43,7 @@
 #
 #	Group b -- Embedded headword
 #	3 Embedded_clerical		: 埋字 隷書字体
-#	4 Embedded_omitted		: 埋字 脱落
+#	4 Embedded-omitted		: 埋字 脱落
 #	5 Embedded_seal			: 埋字 篆書字体
 #
 #	Group c -- Omitted headword


### PR DESCRIPTION
KTB.tsv, KTB_entries.txtの冒頭のコメントにて、
Entry_typeが取り得る定義済み文字列の中に"Embedded_omitted"があるのですが、
実際に使われているのは"Embedded-omitted"であるように見えます。
（アンダースコア"_"で区切るか、ハイフン"-"で区切るかの違い）

コメントを修正するのと、データを修正するのと、どちらが良いでしょうか？
このPRではコメントのほうを修正してみました。